### PR TITLE
Add consumer profile to audit

### DIFF
--- a/charts/hocs-audit/Chart.yaml
+++ b/charts/hocs-audit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-audit
-version: 3.0.2
+version: 3.0.3
 dependencies:
   - name: hocs-generic-service
     version: ^3.0.0

--- a/charts/hocs-audit/values.yaml
+++ b/charts/hocs-audit/values.yaml
@@ -13,7 +13,7 @@ hocs-generic-service:
         -Dhttps.proxyHost=hocs-outbound-proxy.{{ .Release.Namespace }}.svc.cluster.local
         -Dhttps.proxyPort=31290
         -Dhttp.nonProxyHosts=*.{{ .Release.Namespace }}.svc.cluster.local
-      springProfiles: 'sqs'
+      springProfiles: 'sqs, consumer'
 
 dcuCaseView:
   enabled: false


### PR DESCRIPTION
To enable simpler toggling of consuming from the queue, this change adds the `consumer` profile to the hocs-audit chart.