### PR TITLE
Change search queue consuming behaviour

### DIFF
--- a/charts/hocs-search-consumer/Chart.yaml
+++ b/charts/hocs-search-consumer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-search-consumer
-version: 3.0.3
+version: 3.1.0
 dependencies:
   - name: hocs-generic-service
     version: ^3.0.0

--- a/charts/hocs-search-consumer/values.yaml
+++ b/charts/hocs-search-consumer/values.yaml
@@ -16,7 +16,7 @@ hocs-generic-service:
         -Dhttps.proxyHost=hocs-outbound-proxy.{{ .Release.Namespace }}.svc.cluster.local
         -Dhttps.proxyPort=31290
         -Dhttp.nonProxyHosts=*.{{ .Release.Namespace }}.svc.cluster.local
-      springProfiles: 'aws'
+      springProfiles: 'aws, consumer'
       elasticPrefix: '{{ .Release.Namespace }}-latest'
       elasticMode: ''
       searchQueueName: '{{ .Release.Namespace }}-search-sqs'

--- a/charts/hocs-search/Chart.yaml
+++ b/charts/hocs-search/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-search
-version: 3.0.3
+version: 4.0.0
 dependencies:
   - name: hocs-generic-service
     version: ^3.0.0

--- a/charts/hocs-search/templates/_envs.tpl
+++ b/charts/hocs-search/templates/_envs.tpl
@@ -17,8 +17,6 @@
   value: '{{ include "hocs-app.port" . }}'
 - name: SPRING_PROFILES_ACTIVE
   value: '{{ tpl .Values.app.env.springProfiles . }}'
-- name: AWS_SQS_ENABLED
-  value: 'false'
 - name: ELASTICSEARCH_INDEX_PREFIX
   value: '{{ tpl .Values.app.env.elasticPrefix . }}'
 - name: ELASTICSEARCH_MODE


### PR DESCRIPTION
Updates:

- Add consumer to the search-consumer chart.
- Now use the values file for each deployment to specify if the AWS_SQS_ENABLED env is set.