### PR TITLE
✨ HOCS-5561: Allow Deployment name to be different to the chart name.

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -5,4 +5,4 @@ description: A Helm chart for generic services.
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.0
+version: 3.2.0

--- a/charts/generic-service/templates/_helpers.tpl
+++ b/charts/generic-service/templates/_helpers.tpl
@@ -6,6 +6,13 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Expand the name of the chart.
+*/}}
+{{- define "hocs-deploymentEnvs.name" -}}
+{{- default .Values.nameOverride .Values.deploymentEnvs | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "hocs-app.selectorLabels" -}}

--- a/charts/generic-service/templates/deployment.yaml
+++ b/charts/generic-service/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
             - configMapRef:
                 name: hocs-queue-config
           env:
-            {{- include (printf "%s.%s" .Values.nameOverride "envs") . | nindent 12 }}
+            {{- include (printf "%s.%s" (include "hocs-deploymentEnvs.name" .) "envs") . | nindent 12 }}
           resources: {{- toYaml .Values.app.resources | nindent 12 }}
           ports:
             - name: {{ .Values.service.portName }}


### PR DESCRIPTION
We want to deploy to prod using a 'clean' deployment but the environment variables env file is currently locked to the deployment name. This change allows us to pass a nameOverride of 'decs-casework' and a reference to deployment envs of 'hocs-casework'