### PR TITLE
🐛 HOCS-5561: Disable service from Notify

### DIFF
--- a/charts/hocs-notify/Chart.yaml
+++ b/charts/hocs-notify/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-notify
-version: 3.0.4
+version: 3.0.5
 dependencies:
   - name: hocs-generic-service
     version: ^3.0.0

--- a/charts/hocs-notify/values.yaml
+++ b/charts/hocs-notify/values.yaml
@@ -2,6 +2,9 @@
 hocs-generic-service:
   nameOverride: hocs-notify
 
+  service:
+    enabled: false
+
   app:
     image:
       repository: quay.io/ukhomeofficedigital/hocs-notify


### PR DESCRIPTION
Notify doesn't require a service as it doesn't have any rest endpoints