### PR TITLE
HOCS-6004: move mat-view cronjob to extract chart

### DIFF
--- a/charts/hocs-audit/Chart.yaml
+++ b/charts/hocs-audit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-audit
-version: 3.0.6
+version: 3.0.7
 dependencies:
   - name: hocs-generic-service
     version: ^3.0.0

--- a/charts/hocs-audit/values.yaml
+++ b/charts/hocs-audit/values.yaml
@@ -17,4 +17,3 @@ hocs-generic-service:
 
 dcuCaseView:
   enabled: false
-  refresh: '30 5 * * *'

--- a/charts/hocs-extracts/Chart.yaml
+++ b/charts/hocs-extracts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-extracts
-version: 3.1.1
+version: 3.2.0
 dependencies:
   - name: hocs-generic-service
     version: ^3.0.0

--- a/charts/hocs-extracts/templates/refreshDcuAggregatedCasesView.yaml
+++ b/charts/hocs-extracts/templates/refreshDcuAggregatedCasesView.yaml
@@ -23,6 +23,6 @@ spec:
               image: quay.io/ukhomeofficedigital/hocs-base-image:latest
               command: [ "/bin/sh", "-c" ]
               args:
-                - "curl -vk -X POST -H 'User-Agent: Refresh DCU_AGGREGATED_CASES' https://hocs-audit.{{ .Release.Namespace }}.svc.cluster.local/admin/export/custom/DCU_AGGREGATED_CASES/refresh"
+                - "curl -vk -X POST -H 'User-Agent: Refresh DCU_AGGREGATED_CASES' https://hocs-extracts.{{ .Release.Namespace }}.svc.cluster.local/admin/export/custom/DCU_AGGREGATED_CASES/refresh"
           restartPolicy: Never
-  {{- end }}
+{{- end }}

--- a/charts/hocs-extracts/values.yaml
+++ b/charts/hocs-extracts/values.yaml
@@ -102,3 +102,7 @@ hocs-generic-service:
       springProfiles: 'extracts'
       infoService: https://hocs-info-service.{{ .Release.Namespace }}.svc.cluster.local
       caseService: https://hocs-casework.{{ .Release.Namespace }}.svc.cluster.local
+
+dcuCaseView:
+  enabled: false
+  refresh: '30 5 * * *'


### PR DESCRIPTION
Audit no longer has the API endpoints enabled due to a profile restriction, this change moves the CronJob to extracts as that has the endpoints enabled.

As its expected that extracts is going to have a read only replica, this will shortly be moved out of an API call and into a DB cronjob.