### PR TITLE
🐛 HOCS-6000: Add 'https://' to the keycloak cookie domain.

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: hocs-generic-service
 description: A Helm chart for generic services.
-version: 3.4.1
+version: 3.4.2

--- a/charts/generic-service/templates/deployment.yaml
+++ b/charts/generic-service/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
           args: {{- tpl (toYaml .Values.keycloak.args) . | nindent 12 }}
           {{- if not .Values.ingress.internal.enabled }}
             - --redirection-url=https://{{ .Values.keycloak.domain }}
-            - --cookie-domain={{ .Values.keycloak.domain }}
+            - --cookie-domain=https://{{ .Values.keycloak.domain }}
           {{- end }}
           volumeMounts: {{- toYaml .Values.keycloak.volumeMounts | nindent 12 }}
           ports:
@@ -78,7 +78,7 @@ spec:
           args: {{- tpl (toYaml .Values.keycloakApi.args) . | nindent 12 }}
           {{- if not .Values.ingress.internal.enabled }}
             - --redirection-url=https://{{ .Values.keycloak.domain }}
-            - --cookie-domain={{ .Values.keycloak.domain }}
+            - --cookie-domain=https://{{ .Values.keycloak.domain }}
           {{- end }}
           volumeMounts: {{- toYaml .Values.keycloak.volumeMounts | nindent 12 }}
           ports:


### PR DESCRIPTION
This was present in the non-helm deployment