### PR TITLE
HOCS-5996: use queue settings for spring profiles

### DIFF
--- a/charts/hocs-queue-tool/Chart.yaml
+++ b/charts/hocs-queue-tool/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-queue-tool
-version: 3.0.4
+version: 4.0.0
 dependencies:
   - name: hocs-generic-service
     version: ^3.0.0

--- a/charts/hocs-queue-tool/templates/_envs.tpl
+++ b/charts/hocs-queue-tool/templates/_envs.tpl
@@ -16,7 +16,7 @@
 - name: SERVER_PORT
   value: '{{ include "hocs-app.port" . }}'
 - name: SPRING_PROFILES_ACTIVE
-  value: '{{ tpl .Values.app.env.springProfiles . }}'
+  value: '{{ join "," .Values.app.env.queues | lower }}'
 {{- range .Values.app.env.queues }}
 - name: {{. | title | replace "-" "_" | upper }}_QUEUE
   valueFrom:

--- a/charts/hocs-queue-tool/values.yaml
+++ b/charts/hocs-queue-tool/values.yaml
@@ -21,5 +21,4 @@ hocs-generic-service:
         -Dhttps.proxyHost=hocs-outbound-proxy.{{ .Release.Namespace }}.svc.cluster.local
         -Dhttps.proxyPort=31290
         -Dhttp.nonProxyHosts=*.{{ .Release.Namespace }}.svc.cluster.local
-      springProfiles: 'aws'
       queues: []


### PR DESCRIPTION
Pass through the environmental queue settings as a comma seperated values into the spring profile environment variable.