### PR TITLE
HOCS-5984: add base OpenSearch charts

### DIFF
--- a/charts/hocs-search-consumer-opensearch/Chart.yaml
+++ b/charts/hocs-search-consumer-opensearch/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: hocs-search-consumer-opensearch
+version: 1.0.0
+dependencies:
+  - name: hocs-generic-service
+    version: ^3.0.0
+    repository: https://ukhomeoffice.github.io/hocs-helm-charts

--- a/charts/hocs-search-consumer-opensearch/templates/_envs.tpl
+++ b/charts/hocs-search-consumer-opensearch/templates/_envs.tpl
@@ -1,0 +1,56 @@
+{{- define "hocs-search-consumer-opensearch.envs" }}
+- name: JAVA_OPTS
+  value: '{{ tpl .Values.app.env.javaOpts . }}'
+{{- if not .Values.proxy.enabled }}
+- name: SERVER_SSL_KEY_STORE_TYPE
+  value: 'PKCS12'
+- name: SERVER_SSL_KEY_STORE_PASSWORD
+  value: 'changeit'
+- name: SERVER_SSL_KEY_STORE
+  value: 'file:/etc/keystore/keystore.jks'
+- name: SERVER_COMPRESSION_ENABLED
+  value: 'true'
+- name: SERVER_SSL_ENABLED
+  value: 'true'
+{{- end }}
+- name: SERVER_PORT
+  value: '{{ include "hocs-app.port" . }}'
+- name: SPRING_PROFILES_ACTIVE
+  value: '{{ tpl .Values.app.env.springProfiles . }}'
+- name: ELASTICSEARCH_INDEX_PREFIX
+  value: '{{ tpl .Values.app.env.elasticPrefix . }}'
+- name: ELASTICSEARCH_MODE
+  value: '{{ tpl .Values.app.env.elasticMode . }}'
+- name: SEARCH_SQS_QUEUE_NAME
+  value: '{{ tpl .Values.app.env.searchQueueName . }}'
+- name: ELASTICSEARCH_HOST
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-opensearch
+      key: endpoint
+- name: ELASTICSEARCH_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-opensearch
+      key: access_key_id
+- name: ELASTICSEARCH_SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-opensearch
+      key: secret_access_key
+- name: SEARCH_SQS_QUEUE_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-opensearch-sqs
+      key: sqs_queue_url
+- name: SEARCH_SQS_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-opensearch-sqs
+      key: access_key_id
+- name: SEARCH_SQS_SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-opensearch-sqs
+      key: secret_access_key
+{{- end -}}

--- a/charts/hocs-search-consumer-opensearch/values.yaml
+++ b/charts/hocs-search-consumer-opensearch/values.yaml
@@ -1,0 +1,22 @@
+---
+hocs-generic-service:
+  nameOverride: hocs-search-consumer-opensearch
+
+  service:
+    enabled: false
+
+  app:
+    image:
+      repository: quay.io/ukhomeofficedigital/hocs-search
+    env:
+      javaOpts: >-
+        -XX:InitialRAMPercentage=50 -XX:MaxRAMPercentage=65
+        -Djava.security.egd=file:/dev/./urandom
+        -Djavax.net.ssl.trustStore=/etc/keystore/truststore.jks
+        -Dhttps.proxyHost=hocs-outbound-proxy.{{ .Release.Namespace }}.svc.cluster.local
+        -Dhttps.proxyPort=31290
+        -Dhttp.nonProxyHosts=*.{{ .Release.Namespace }}.svc.cluster.local
+      springProfiles: 'aws, consumer'
+      elasticPrefix: '{{ .Release.Namespace }}-latest'
+      elasticMode: ''
+      searchQueueName: '{{ .Release.Namespace }}-opensearch-sqs'

--- a/charts/hocs-search-opensearch/Chart.yaml
+++ b/charts/hocs-search-opensearch/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: hocs-search-opensearch
+version: 1.0.0
+dependencies:
+  - name: hocs-generic-service
+    version: ^3.0.0
+    repository: https://ukhomeoffice.github.io/hocs-helm-charts

--- a/charts/hocs-search-opensearch/templates/_envs.tpl
+++ b/charts/hocs-search-opensearch/templates/_envs.tpl
@@ -1,0 +1,39 @@
+{{- define "hocs-search-opensearch.envs" }}
+- name: JAVA_OPTS
+  value: '{{ tpl .Values.app.env.javaOpts . }}'
+{{- if not .Values.proxy.enabled }}
+- name: SERVER_SSL_KEY_STORE_TYPE
+  value: 'PKCS12'
+- name: SERVER_SSL_KEY_STORE_PASSWORD
+  value: 'changeit'
+- name: SERVER_SSL_KEY_STORE
+  value: 'file:/etc/keystore/keystore.jks'
+- name: SERVER_COMPRESSION_ENABLED
+  value: 'true'
+- name: SERVER_SSL_ENABLED
+  value: 'true'
+{{- end }}
+- name: SERVER_PORT
+  value: '{{ include "hocs-app.port" . }}'
+- name: SPRING_PROFILES_ACTIVE
+  value: '{{ tpl .Values.app.env.springProfiles . }}'
+- name: ELASTICSEARCH_INDEX_PREFIX
+  value: '{{ tpl .Values.app.env.elasticPrefix . }}'
+- name: ELASTICSEARCH_MODE
+  value: '{{ tpl .Values.app.env.elasticMode . }}'
+- name: ELASTICSEARCH_HOST
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-opensearch
+      key: endpoint
+- name: ELASTICSEARCH_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-opensearch
+      key: access_key_id
+- name: ELASTICSEARCH_SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-opensearch
+      key: secret_access_key
+{{- end -}}

--- a/charts/hocs-search-opensearch/values.yaml
+++ b/charts/hocs-search-opensearch/values.yaml
@@ -1,0 +1,19 @@
+---
+hocs-generic-service:
+  nameOverride: hocs-search-opensearch
+
+  app:
+    image:
+      repository: quay.io/ukhomeofficedigital/hocs-search
+    env:
+      javaOpts: >-
+        -XX:InitialRAMPercentage=50 -XX:MaxRAMPercentage=65
+        -Djava.security.egd=file:/dev/./urandom
+        -Djavax.net.ssl.trustStore=/etc/keystore/truststore.jks
+        -Dhttps.proxyHost=hocs-outbound-proxy.{{ .Release.Namespace }}.svc.cluster.local
+        -Dhttps.proxyPort=31290
+        -Dhttp.nonProxyHosts=*.{{ .Release.Namespace }}.svc.cluster.local
+      springProfiles: 'aws'
+      elasticPrefix: '{{ .Release.Namespace }}-latest'
+      elasticMode: ''
+      searchQueueName: '{{ .Release.Namespace }}-opensearch-sqs'


### PR DESCRIPTION
Add the base charts at version 1.0.0 for both the OpenSearch consumer and API.