### PR TITLE
HOCS-6146:  move materialised view from extracts to audit

### DIFF
--- a/charts/hocs-audit/Chart.yaml
+++ b/charts/hocs-audit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-audit
-version: 4.0.3
+version: 4.1.0
 dependencies:
   - name: hocs-generic-service
     version: ^5.0.0

--- a/charts/hocs-audit/templates/_envs.tpl
+++ b/charts/hocs-audit/templates/_envs.tpl
@@ -47,6 +47,8 @@
     secretKeyRef:
       name: {{ .Release.Namespace }}-audit-rds
       key: password
+- name: DB_QUERY_TIMEOUT
+  value: '0'
 - name: AUDIT_QUEUE_NAME
   value: {{ .Release.Namespace }}-audit-sqs
 - name: AWS_SQS_AUDIT_URL

--- a/charts/hocs-audit/templates/hocs-refresh-dcu-cases-view-job-networkpolicy.yaml
+++ b/charts/hocs-audit/templates/hocs-refresh-dcu-cases-view-job-networkpolicy.yaml
@@ -16,4 +16,4 @@ spec:
       to:
         - podSelector:
             matchLabels:
-              role: hocs-extracts
+              role: hocs-audit

--- a/charts/hocs-audit/templates/refresh-dcu-cases-view-job.yaml
+++ b/charts/hocs-audit/templates/refresh-dcu-cases-view-job.yaml
@@ -25,6 +25,6 @@ spec:
               image: quay.io/ukhomeofficedigital/hocs-base-image:latest
               command: [ "/bin/sh", "-c" ]
               args:
-                - "curl -vk -X POST -H 'User-Agent: Refresh DCU_AGGREGATED_CASES' https://hocs-extracts.{{ .Release.Namespace }}.svc.cluster.local/admin/export/custom/DCU_AGGREGATED_CASES/refresh"
+                - "curl -vk -X POST -H 'User-Agent: Refresh DCU_AGGREGATED_CASES' https://hocs-audit.{{ .Release.Namespace }}.svc.cluster.local/admin/export/custom/DCU_AGGREGATED_CASES/refresh"
           restartPolicy: Never
 {{- end }}

--- a/charts/hocs-audit/values.yaml
+++ b/charts/hocs-audit/values.yaml
@@ -23,3 +23,4 @@ hocs-generic-service:
 
 dcuCaseView:
   enabled: false
+  refresh: '30 5 * * *'

--- a/charts/hocs-extracts/Chart.yaml
+++ b/charts/hocs-extracts/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-extracts
-version: 4.1.1
+version: 5.0.0
 dependencies:
   - name: hocs-generic-service
     version: ^5.0.0

--- a/charts/hocs-extracts/values.yaml
+++ b/charts/hocs-extracts/values.yaml
@@ -113,4 +113,3 @@ hocs-generic-service:
 
 dcuCaseView:
   enabled: false
-  refresh: '30 5 * * *'


### PR DESCRIPTION
As the materialised view cannot fully be run from the extracts
deployment, this has been moved to the audit service again.

As the audit service does not serve long-running commands from the
users and only needs to support the materialised job refresh. This can
have the timeout deactivated on the service - this overwrites the
default 60 seconds on the service.
