### PR TITLE
HOCS-6243: change ignore message property

### DIFF
--- a/charts/hocs-case-creator/Chart.yaml
+++ b/charts/hocs-case-creator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-case-creator
-version: 4.0.2
+version: 4.1.0
 dependencies:
   - name: hocs-generic-service
     version: ^5.0.0

--- a/charts/hocs-case-creator/Chart.yaml
+++ b/charts/hocs-case-creator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-case-creator
-version: 4.1.0
+version: 5.0.0
 dependencies:
   - name: hocs-generic-service
     version: ^5.0.0

--- a/charts/hocs-case-creator/templates/_envs.tpl
+++ b/charts/hocs-case-creator/templates/_envs.tpl
@@ -21,8 +21,8 @@
   value: '{{ tpl .Values.app.env.caseworkService . }}'
 - name: CASE_CREATOR_WORKFLOW_SERVICE
   value: '{{ tpl .Values.app.env.workflowService . }}'
-- name: MESSAGE_IGNORED_TYPES
-  value: '{{ tpl .Values.app.env.ignoredTypes . }}'
+- name: AWS_SQS_IGNORE_MESSAGES
+  value: '{{ tpl .Values.app.env.ignoreMessages . }}'
 - name: AWS_SQS_CASE_CREATOR_ACCOUNT_ACCESS_KEY
   valueFrom:
     secretKeyRef:

--- a/charts/hocs-case-creator/values.yaml
+++ b/charts/hocs-case-creator/values.yaml
@@ -23,4 +23,4 @@ hocs-generic-service:
       springProfiles: 'sqs, s3, ukvi'
       caseworkService: https://hocs-casework.{{ .Release.Namespace }}.svc.cluster.local
       workflowService: https://hocs-workflow.{{ .Release.Namespace }}.svc.cluster.local
-      ignoredTypes: ''
+      ignoreMessages: 'false'

--- a/charts/hocs-case-creator/values.yaml
+++ b/charts/hocs-case-creator/values.yaml
@@ -20,7 +20,7 @@ hocs-generic-service:
         -Dhttps.proxyHost=hocs-outbound-proxy.{{ .Release.Namespace }}.svc.cluster.local
         -Dhttps.proxyPort=31290
         -Dhttp.nonProxyHosts=*.{{ .Release.Namespace }}.svc.cluster.local
-      springProfiles: 'sqs, s3'
+      springProfiles: 'sqs, s3, ukvi'
       caseworkService: https://hocs-casework.{{ .Release.Namespace }}.svc.cluster.local
       workflowService: https://hocs-workflow.{{ .Release.Namespace }}.svc.cluster.local
       ignoredTypes: ''

--- a/charts/hocs-case-migrator/Chart.yaml
+++ b/charts/hocs-case-migrator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-case-migrator
-version: 4.1.0
+version: 5.0.0
 dependencies:
   - name: hocs-generic-service
     version: ^5.0.0

--- a/charts/hocs-case-migrator/Chart.yaml
+++ b/charts/hocs-case-migrator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-case-migrator
-version: 5.0.0
+version: 6.0.0
 dependencies:
   - name: hocs-generic-service
     version: ^5.0.0

--- a/charts/hocs-case-migrator/Chart.yaml
+++ b/charts/hocs-case-migrator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-case-migrator
-version: 4.0.2
+version: 4.1.0
 dependencies:
   - name: hocs-generic-service
     version: ^5.0.0

--- a/charts/hocs-case-migrator/templates/_envs.tpl
+++ b/charts/hocs-case-migrator/templates/_envs.tpl
@@ -23,8 +23,6 @@
   value: '{{ tpl .Values.app.env.workflowService . }}'
 - name: MESSAGE_IGNORED_TYPES
   value: '{{ tpl .Values.app.env.ignoredTypes . }}'
-- name: CASE_CREATOR_MODE
-  value: 'migration'
 - name: AWS_SQS_CASE_CREATOR_ACCOUNT_ACCESS_KEY
   valueFrom:
     secretKeyRef:

--- a/charts/hocs-case-migrator/templates/_envs.tpl
+++ b/charts/hocs-case-migrator/templates/_envs.tpl
@@ -21,8 +21,8 @@
   value: '{{ tpl .Values.app.env.caseworkService . }}'
 - name: CASE_CREATOR_WORKFLOW_SERVICE
   value: '{{ tpl .Values.app.env.workflowService . }}'
-- name: MESSAGE_IGNORED_TYPES
-  value: '{{ tpl .Values.app.env.ignoredTypes . }}'
+- name: AWS_SQS_IGNORE_MESSAGES
+  value: '{{ tpl .Values.app.env.ignoreMessages . }}'
 - name: AWS_SQS_CASE_CREATOR_ACCOUNT_ACCESS_KEY
   valueFrom:
     secretKeyRef:

--- a/charts/hocs-case-migrator/values.yaml
+++ b/charts/hocs-case-migrator/values.yaml
@@ -20,7 +20,7 @@ hocs-generic-service:
         -Dhttps.proxyHost=hocs-outbound-proxy.{{ .Release.Namespace }}.svc.cluster.local
         -Dhttps.proxyPort=31290
         -Dhttp.nonProxyHosts=*.{{ .Release.Namespace }}.svc.cluster.local
-      springProfiles: 'sqs, s3'
+      springProfiles: 'sqs, s3, migration'
       caseworkService: https://hocs-casework.{{ .Release.Namespace }}.svc.cluster.local
       workflowService: https://hocs-workflow.{{ .Release.Namespace }}.svc.cluster.local
       ignoredTypes: ''

--- a/charts/hocs-case-migrator/values.yaml
+++ b/charts/hocs-case-migrator/values.yaml
@@ -23,4 +23,4 @@ hocs-generic-service:
       springProfiles: 'sqs, s3, migration'
       caseworkService: https://hocs-casework.{{ .Release.Namespace }}.svc.cluster.local
       workflowService: https://hocs-workflow.{{ .Release.Namespace }}.svc.cluster.local
-      ignoredTypes: ''
+      ignoreMessages: 'false'


### PR DESCRIPTION
Change to case creator deployments to use a boolean property for ignoring the messages. This by default is set to false but should be overridden within respective environments.