### PR TITLE
HOCS-6168: add database environment variables

### DIFF
--- a/charts/hocs-case-creator/Chart.yaml
+++ b/charts/hocs-case-creator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-case-creator
-version: 5.0.0
+version: 5.1.0
 dependencies:
   - name: hocs-generic-service
     version: ^5.0.0

--- a/charts/hocs-case-creator/templates/_envs.tpl
+++ b/charts/hocs-case-creator/templates/_envs.tpl
@@ -73,4 +73,34 @@
     secretKeyRef:
       name: hocs-case-creator-identities
       key: complaint_ukvi_team
+- name: DB_HOST
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-case-creator-rds
+      key: host
+- name: DB_PORT
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-case-creator-rds
+      key: port
+- name: DB_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-case-creator-rds
+      key: name
+- name: DB_SCHEMA_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-case-creator-rds
+      key: schema_name
+- name: DB_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-case-creator-rds
+      key: user_name
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-case-creator-rds
+      key: password
 {{- end -}}

--- a/charts/hocs-case-migrator/Chart.yaml
+++ b/charts/hocs-case-migrator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-case-migrator
-version: 6.0.0
+version: 6.1.0
 dependencies:
   - name: hocs-generic-service
     version: ^5.0.0

--- a/charts/hocs-case-migrator/templates/_envs.tpl
+++ b/charts/hocs-case-migrator/templates/_envs.tpl
@@ -78,4 +78,34 @@
     secretKeyRef:
       name: hocs-case-migrator-identities
       key: migration_user
+- name: DB_HOST
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-case-migrator-rds
+      key: host
+- name: DB_PORT
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-case-migrator-rds
+      key: port
+- name: DB_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-case-migrator-rds
+      key: name
+- name: DB_SCHEMA_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-case-migrator-rds
+      key: schema_name
+- name: DB_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-case-migrator-rds
+      key: user_name
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Namespace }}-case-migrator-rds
+      key: password
 {{- end -}}


### PR DESCRIPTION
Add the corresponding environment database variables that should be used for connection to the database for both case-creator and the case-migrator.