### PR TITLE
HOCS-6168: add missing pod label

### DIFF
--- a/charts/hocs-case-creator/Chart.yaml
+++ b/charts/hocs-case-creator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-case-creator
-version: 6.0.0
+version: 6.0.1
 dependencies:
   - name: hocs-generic-service
     version: ^5.0.0

--- a/charts/hocs-case-creator/values.yaml
+++ b/charts/hocs-case-creator/values.yaml
@@ -5,6 +5,8 @@ hocs-generic-service:
   selector:
     outbound:
       required: true
+    database:
+      required: true
 
   service:
     enabled: false

--- a/charts/hocs-case-migrator/Chart.yaml
+++ b/charts/hocs-case-migrator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-case-migrator
-version: 7.0.0
+version: 7.0.1
 dependencies:
   - name: hocs-generic-service
     version: ^5.0.0

--- a/charts/hocs-case-migrator/values.yaml
+++ b/charts/hocs-case-migrator/values.yaml
@@ -5,6 +5,8 @@ hocs-generic-service:
   selector:
     outbound:
       required: true
+    database:
+      required: true
 
   service:
     enabled: false


### PR DESCRIPTION
As the case creator services need access to the RDS now, this change adds the missing label that allows this communication with the environment network policies.