### PR TITLE
Allow manual release charts trigger

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This change allows for the manual triggering of the release charts workflow job for when patches need to be applied to previous major/minor versions.