### PR TITLE
HOCS-6249: add processing cron job

### DIFF
--- a/charts/hocs-case-creator/Chart.yaml
+++ b/charts/hocs-case-creator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-case-creator
-version: 6.0.1
+version: 6.1.0
 dependencies:
   - name: hocs-generic-service
     version: ^5.0.0

--- a/charts/hocs-case-creator/templates/process-messages-job.yml
+++ b/charts/hocs-case-creator/templates/process-messages-job.yml
@@ -1,0 +1,41 @@
+{{- if .Values.jobs.process.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: hocs-case-creator-process-messages
+  labels:
+    role: hocs-case-creator-process-messages
+spec:
+  schedule: {{ .Values.jobs.process.schedule }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            name: hocs-case-creator-process-messages
+            role: hocs-case-creator-process-messages
+        spec:
+          containers:
+            - name: hocs-case-creator-process-messages
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+              image: quay.io/ukhomeofficedigital/hocs-base-image:latest
+              command: [ "/bin/sh", "-c" ]
+              args:
+                - |
+                  curl -vk
+                  -H 'User-Agent: Process Messages' 
+                  -H 'Content-Type: application/json' 
+                  https://hocs-case-creator.{{ .Release.Namespace }}.svc.cluster.local/process
+                  -d "{ \"maxMessages\": ${MAX_MESSAGES} }"
+              env:
+                - name: MAX_MESSAGES
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Release.Namespace }}-case-creator
+                      key: max_messages
+          restartPolicy: Never
+{{- end }}

--- a/charts/hocs-case-creator/values.yaml
+++ b/charts/hocs-case-creator/values.yaml
@@ -27,4 +27,4 @@ hocs-generic-service:
 jobs:
   process:
     enabled: false
-    schedule: '0 7-22 * * 1-5'
+    schedule: '0 8-18 * * 1-5'

--- a/charts/hocs-case-creator/values.yaml
+++ b/charts/hocs-case-creator/values.yaml
@@ -8,9 +8,6 @@ hocs-generic-service:
     database:
       required: true
 
-  service:
-    enabled: false
-
   app:
     image:
       repository: quay.io/ukhomeofficedigital/hocs-case-creator
@@ -26,3 +23,8 @@ hocs-generic-service:
       caseworkService: https://hocs-casework.{{ .Release.Namespace }}.svc.cluster.local
       workflowService: https://hocs-workflow.{{ .Release.Namespace }}.svc.cluster.local
       ignoreMessages: 'false'
+
+jobs:
+  process:
+    enabled: false
+    schedule: '0 7-22 * * 1-5'


### PR DESCRIPTION
Add processing cronjob to the deployment for case creator. This is set to not deploy by default, to ensure that environments don't try to use this prematurely. This job sends a POST request through to case-creator via its newly added service to process up to `maxMessages` amount of messages.