### PR TITLE
Fix process messages cronjob

### DIFF
--- a/charts/hocs-case-creator/Chart.yaml
+++ b/charts/hocs-case-creator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-case-creator
-version: 7.0.0
+version: 7.0.1
 dependencies:
   - name: hocs-generic-service
     version: ^5.0.0

--- a/charts/hocs-case-creator/templates/hocs-case-creator-process-messages-job-networkpolicy.yaml
+++ b/charts/hocs-case-creator/templates/hocs-case-creator-process-messages-job-networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hocs-case-creator-process-messages-job-policy
+spec:
+  podSelector:
+    matchLabels:
+      role: hocs-case-creator-process-messages-job
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 10443
+          protocol: TCP
+      to:
+        - podSelector:
+            matchLabels:
+              role: hocs-case-creator

--- a/charts/hocs-case-creator/templates/hocs-case-creator-process-messages-job.yml
+++ b/charts/hocs-case-creator/templates/hocs-case-creator-process-messages-job.yml
@@ -2,9 +2,9 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: hocs-case-creator-process-messages
+  name: hocs-case-creator-process-messages-job
   labels:
-    role: hocs-case-creator-process-messages
+    role: hocs-case-creator-process-messages-job
 spec:
   schedule: {{ .Values.jobs.process.schedule }}
   concurrencyPolicy: Forbid
@@ -14,23 +14,18 @@ spec:
       template:
         metadata:
           labels:
-            name: hocs-case-creator-process-messages
-            role: hocs-case-creator-process-messages
+            name: hocs-case-creator-process-messages-job
+            role: hocs-case-creator-process-messages-job
         spec:
           containers:
-            - name: hocs-case-creator-process-messages
+            - name: hocs-case-creator-process-messages-job
               securityContext:
                 runAsNonRoot: true
                 runAsUser: 1000
               image: quay.io/ukhomeofficedigital/hocs-base-image:latest
               command: [ "/bin/sh", "-c" ]
               args:
-                - |
-                  curl -vk
-                  -H 'User-Agent: Process Messages' 
-                  -H 'Content-Type: application/json' 
-                  https://hocs-case-creator.{{ .Release.Namespace }}.svc.cluster.local/process
-                  -d "{ \"maxMessages\": ${MAX_MESSAGES} }"
+                - "curl -vk https://hocs-case-creator.{{ .Release.Namespace }}.svc.cluster.local/process -H \"User-Agent: Process Messages\" -H \"Content-Type: application/json\" -d \"{ \"maxMessages\": $MAX_MESSAGES }\""
               env:
                 - name: MAX_MESSAGES
                   valueFrom:


### PR DESCRIPTION
Kubernetes does not support multi-line with args blocks, this change fixes the process-messages-job.yml to correctly run the curl command.