### PR TITLE
HOCS-6418: correctly handle curl response

### DIFF
--- a/charts/hocs-case-creator/Chart.yaml
+++ b/charts/hocs-case-creator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-case-creator
-version: 7.1.0
+version: 7.1.1
 dependencies:
   - name: hocs-generic-service
     version: ^5.3.0

--- a/charts/hocs-case-creator/templates/hocs-case-creator-process-messages-job.yml
+++ b/charts/hocs-case-creator/templates/hocs-case-creator-process-messages-job.yml
@@ -25,7 +25,7 @@ spec:
               image: quay.io/ukhomeofficedigital/hocs-base-image:latest
               command: [ "/bin/sh", "-c" ]
               args:
-                - 'http_status = $(curl -vk https://hocs-case-creator.{{ .Release.Namespace }}.svc.cluster.local/process -H "User-Agent: Process Messages" -H "Content-Type: application/json" -d "{ \"maxMessages\": $MAX_MESSAGES }");if [[ $http_status -eq 200 ]]; then exit 0; else exit 1; fi'
+                - 'http_status=$(curl -vk -w "%{http_code}" https://hocs-case-creator.{{ .Release.Namespace }}.svc.cluster.local/process -H "User-Agent: Process Messages" -H "Content-Type: application/json" -d "{ \"maxMessages\": $MAX_MESSAGES }"); if [ $http_status -eq 200 ]; then exit 0; else exit 1; fi'
               env:
                 - name: MAX_MESSAGES
                   valueFrom:


### PR DESCRIPTION
The current solution fails the cronjob on every run invocation. This change fixes a number of issues with the argument passed:

- Remove spaces around variable assignation, the space after the equals attempts to run a method called http_status that does not exist. Removing the spaces treats this as variable assignation.
- Add `%{http_code}` watch return that tells curl to write out the status code.
- Remove double square brackets as our base image does not alias bash to shell.