### PR TITLE
[HOCS-6247] Bump chart version

### DIFF
--- a/charts/hocs-workflow/Chart.yaml
+++ b/charts/hocs-workflow/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hocs-workflow
-version: 4.1.6
+version: 4.1.7
 dependencies:
   - name: hocs-generic-service
     version: ^5.3.3


### PR DESCRIPTION
https://github.com/UKHomeOffice/hocs-helm-charts/pull/110 didn't update chart version so hasn't been applied