### PR TITLE
Hocs txa document extractor

### DIFF
--- a/charts/hocs-txa-document-extractor/Chart.yaml
+++ b/charts/hocs-txa-document-extractor/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: hocs-txa-document-extractor
+version: 1.0.0
+description: Exports a batch of documents to DSA Analytics pipeline.

--- a/charts/hocs-txa-document-extractor/templates/cs-txa-deletes-job.yml
+++ b/charts/hocs-txa-document-extractor/templates/cs-txa-deletes-job.yml
@@ -1,0 +1,53 @@
+{{- if .Values.jobs.cs-deletes.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cs-txa-deletes-job
+spec:
+  schedule: "{{ .Values.jobs.cs-deletes.schedule }}"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      completions: 1
+      backoffLimit: 3
+      template:
+        metadata:
+          labels:
+            name: cs-txa-deletes-job
+        spec:
+          restartPolicy: onFailure
+          securityContext:
+            runAsUser: 10000
+            runAsNonRoot: true
+          containers:
+            - name: cs-txa-deletes-job
+              image: quay.io/ukhomeofficedigital/hocs-txa-document-extractor:{{ .Values.jobs.cs-deletes.imageTag }}
+              imagePullPolicy: Always
+              resources:
+                limits:
+                  memory: "2G"
+                  cpu: "2"
+                requests:
+                  memory: "1G"
+                  cpu: "1"
+              envFrom:
+                - configMapRef:
+                    name: cs-txa-config
+                - secretRef:
+                    name: txa-secrets
+                - secretRef:
+                    name: aws-s3-secrets
+              env:
+                - name: MODE_DELETE
+                  value: "true"
+                - name: JAVA_OPTS
+                  value: "-Xms512m -Xmx1g"
+              volumeMounts:
+                - name: txa-msk-certificates
+                  mountPath: /etc/msk-certs
+                  readOnly: true
+          volumes:
+            - name: txa-msk-certificates
+              secret:
+                secretName: txa-msk-certificates
+{{- end }}

--- a/charts/hocs-txa-document-extractor/templates/cs-txa-ingests-job.yml
+++ b/charts/hocs-txa-document-extractor/templates/cs-txa-ingests-job.yml
@@ -1,0 +1,53 @@
+{{- if .Values.jobs.cs-ingests.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cs-txa-ingests-job
+spec:
+  schedule: "{{ .Values.jobs.cs-ingests.schedule }}"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      completions: 1
+      backoffLimit: 3
+      template:
+        metadata:
+          labels:
+            name: cs-txa-ingests-job
+        spec:
+          restartPolicy: onFailure
+          securityContext:
+            runAsUser: 10000
+            runAsNonRoot: true
+          containers:
+            - name: cs-txa-ingests-job
+              image: quay.io/ukhomeofficedigital/hocs-txa-document-extractor:{{ .Values.jobs.cs-ingests.imageTag }}
+              imagePullPolicy: Always
+              resources:
+                limits:
+                  memory: "2G"
+                  cpu: "2"
+                requests:
+                  memory: "1G"
+                  cpu: "1"
+              envFrom:
+                - configMapRef:
+                    name: cs-txa-config
+                - secretRef:
+                    name: txa-secrets
+                - secretRef:
+                    name: aws-s3-secrets
+              env:
+                - name: MODE_DELETE
+                  value: "false"
+                - name: JAVA_OPTS
+                  value: "-Xms512m -Xmx1g"
+              volumeMounts:
+                - name: txa-msk-certificates
+                  mountPath: /etc/msk-certs
+                  readOnly: true
+          volumes:
+            - name: txa-msk-certificates
+              secret:
+                secretName: txa-msk-certificates
+{{- end }}

--- a/charts/hocs-txa-document-extractor/templates/wcs-txa-deletes-job.yml
+++ b/charts/hocs-txa-document-extractor/templates/wcs-txa-deletes-job.yml
@@ -1,0 +1,53 @@
+{{- if .Values.jobs.wcs-deletes.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: wcs-txa-deletes-job
+spec:
+  schedule: "{{ .Values.jobs.wcs-deletes.schedule }}"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      completions: 1
+      backoffLimit: 3
+      template:
+        metadata:
+          labels:
+            name: wcs-txa-deletes-job
+        spec:
+          restartPolicy: onFailure
+          securityContext:
+            runAsUser: 10000
+            runAsNonRoot: true
+          containers:
+            - name: wcs-txa-deletes-job
+              image: quay.io/ukhomeofficedigital/hocs-txa-document-extractor:{{ .Values.jobs.wcs-deletes.imageTag }}
+              imagePullPolicy: Always
+              resources:
+                limits:
+                  memory: "2G"
+                  cpu: "2"
+                requests:
+                  memory: "1G"
+                  cpu: "1"
+              envFrom:
+                - configMapRef:
+                    name: wcs-txa-config
+                - secretRef:
+                    name: txa-secrets
+                - secretRef:
+                    name: aws-s3-secrets
+              env:
+                - name: MODE_DELETE
+                  value: "true"
+                - name: JAVA_OPTS
+                  value: "-Xms512m -Xmx1g"
+              volumeMounts:
+                - name: txa-msk-certificates
+                  mountPath: /etc/msk-certs
+                  readOnly: true
+          volumes:
+            - name: txa-msk-certificates
+              secret:
+                secretName: txa-msk-certificates
+{{- end }}

--- a/charts/hocs-txa-document-extractor/templates/wcs-txa-ingests-job.yml
+++ b/charts/hocs-txa-document-extractor/templates/wcs-txa-ingests-job.yml
@@ -1,0 +1,53 @@
+{{- if .Values.jobs.wcs-ingests.enabled }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: wcs-txa-ingests-job
+spec:
+  schedule: "{{ .Values.jobs.wcs-ingests.schedule }}"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      completions: 1
+      backoffLimit: 3
+      template:
+        metadata:
+          labels:
+            name: wcs-txa-ingests-job
+        spec:
+          restartPolicy: onFailure
+          securityContext:
+            runAsUser: 10000
+            runAsNonRoot: true
+          containers:
+            - name: wcs-txa-ingests-job
+              image: quay.io/ukhomeofficedigital/hocs-txa-document-extractor:{{ .Values.jobs.wcs-ingests.imageTag }}
+              imagePullPolicy: Always
+              resources:
+                limits:
+                  memory: "2G"
+                  cpu: "2"
+                requests:
+                  memory: "1G"
+                  cpu: "1"
+              envFrom:
+                - configMapRef:
+                    name: wcs-txa-config
+                - secretRef:
+                    name: txa-secrets
+                - secretRef:
+                    name: aws-s3-secrets
+              env:
+                - name: MODE_DELETE
+                  value: "false"
+                - name: JAVA_OPTS
+                  value: "-Xms512m -Xmx1g"
+              volumeMounts:
+                - name: txa-msk-certificates
+                  mountPath: /etc/msk-certs
+                  readOnly: true
+          volumes:
+            - name: txa-msk-certificates
+              secret:
+                secretName: txa-msk-certificates
+{{- end }}

--- a/charts/hocs-txa-document-extractor/values.yaml
+++ b/charts/hocs-txa-document-extractor/values.yaml
@@ -1,0 +1,18 @@
+---
+jobs:
+  cs-ingests:
+    enabled: true
+    schedule: '5 8 * * *'
+    imageTag: 2.0.0
+  cs-deletes:
+    enabled: true
+    schedule: '5 8 * * *'
+    imageTag: 2.0.0
+  wcs-ingests:
+    enabled: true
+    schedule: '5 8 * * *'
+    imageTag: 2.0.0
+  wcs-deletes:
+    enabled: true
+    schedule: '5 8 * * *'
+    imageTag: 2.0.0'


### PR DESCRIPTION
Add helm charts for hocs-txa-document-extractor cronjobs. 1 cronjob for each of:
- ingests from CS to TXA
- ingests from WCS to TXA
- deletes from CS to TXA
- deletes from WCS to TXA
