### PR TITLE
Add prometheus metrics to generic service

### DIFF
--- a/charts/generic-service/Chart.yaml
+++ b/charts/generic-service/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: hocs-generic-service
 description: A generic Helm chart.
-version: 5.3.6
+version: 5.4.0

--- a/charts/generic-service/templates/deployment.yaml
+++ b/charts/generic-service/templates/deployment.yaml
@@ -20,6 +20,13 @@ spec:
   template:
     metadata:
       labels: {{- include "hocs-app.selectorLabels" . | nindent 8 }}
+      {{- if .Values.prometheus.enabled }}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: {{ .Values.prometheus.path | quote }}
+        prometheus.io/port: {{ include "hocs-app.targetPort" . }}
+        prometheus.io/scheme: {{ include "hocs-app.healthcheck.scheme" . }}
+      {{- end }}
     spec:
       affinity:
         podAntiAffinity:

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -172,3 +172,7 @@ ingress:
     ingress.kubernetes.io/server-snippets: |
       client_header_buffer_size     8k;
       large_client_header_buffers   4 128k;
+
+prometheus:
+  enabled: false
+  path: /actuator/prometheus

--- a/charts/hocs-case-creator/Chart.yaml
+++ b/charts/hocs-case-creator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: hocs-case-creator
-version: 7.2.2
+version: 7.3.0
 dependencies:
   - name: hocs-generic-service
-    version: ^5.3.6
+    version: ^5.4.0
     repository: https://ukhomeoffice.github.io/hocs-helm-charts


### PR DESCRIPTION
This adds the ability to add prometheus scrape annotations to a pod to enable metrics to be surfaced in Sysdig.