### PR TITLE
Remove invalid character from hocs-txa-document-extractor Chart

### DIFF
--- a/charts/hocs-txa-document-extractor/Chart.yaml
+++ b/charts/hocs-txa-document-extractor/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: hocs-txa-document-extractor
-version: 1.0.1
+version: 1.0.2
 description: Exports a batch of documents to DSA Analytics pipeline.

--- a/charts/hocs-txa-document-extractor/templates/cs-txa-deletes-job.yml
+++ b/charts/hocs-txa-document-extractor/templates/cs-txa-deletes-job.yml
@@ -1,10 +1,10 @@
-{{- if .Values.jobs.cs-deletes.enabled }}
+{{- if .Values.jobs.csDeletes.enabled }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: cs-txa-deletes-job
 spec:
-  schedule: "{{ .Values.jobs.cs-deletes.schedule }}"
+  schedule: "{{ .Values.jobs.csDeletes.schedule }}"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
@@ -21,7 +21,7 @@ spec:
             runAsNonRoot: true
           containers:
             - name: cs-txa-deletes-job
-              image: quay.io/ukhomeofficedigital/hocs-txa-document-extractor:{{ .Values.jobs.cs-deletes.imageTag }}
+              image: quay.io/ukhomeofficedigital/hocs-txa-document-extractor:{{ .Values.jobs.csDeletes.imageTag }}
               imagePullPolicy: Always
               resources:
                 limits:

--- a/charts/hocs-txa-document-extractor/templates/cs-txa-ingests-job.yml
+++ b/charts/hocs-txa-document-extractor/templates/cs-txa-ingests-job.yml
@@ -1,10 +1,10 @@
-{{- if .Values.jobs.cs-ingests.enabled }}
+{{- if .Values.jobs.csIngests.enabled }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: cs-txa-ingests-job
 spec:
-  schedule: "{{ .Values.jobs.cs-ingests.schedule }}"
+  schedule: "{{ .Values.jobs.csIngests.schedule }}"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
@@ -21,7 +21,7 @@ spec:
             runAsNonRoot: true
           containers:
             - name: cs-txa-ingests-job
-              image: quay.io/ukhomeofficedigital/hocs-txa-document-extractor:{{ .Values.jobs.cs-ingests.imageTag }}
+              image: quay.io/ukhomeofficedigital/hocs-txa-document-extractor:{{ .Values.jobs.csIngests.imageTag }}
               imagePullPolicy: Always
               resources:
                 limits:

--- a/charts/hocs-txa-document-extractor/templates/wcs-txa-deletes-job.yml
+++ b/charts/hocs-txa-document-extractor/templates/wcs-txa-deletes-job.yml
@@ -1,10 +1,10 @@
-{{- if .Values.jobs.wcs-deletes.enabled }}
+{{- if .Values.jobs.wcsDeletes.enabled }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: wcs-txa-deletes-job
 spec:
-  schedule: "{{ .Values.jobs.wcs-deletes.schedule }}"
+  schedule: "{{ .Values.jobs.wcsDeletes.schedule }}"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
@@ -21,7 +21,7 @@ spec:
             runAsNonRoot: true
           containers:
             - name: wcs-txa-deletes-job
-              image: quay.io/ukhomeofficedigital/hocs-txa-document-extractor:{{ .Values.jobs.wcs-deletes.imageTag }}
+              image: quay.io/ukhomeofficedigital/hocs-txa-document-extractor:{{ .Values.jobs.wcsDeletes.imageTag }}
               imagePullPolicy: Always
               resources:
                 limits:

--- a/charts/hocs-txa-document-extractor/templates/wcs-txa-ingests-job.yml
+++ b/charts/hocs-txa-document-extractor/templates/wcs-txa-ingests-job.yml
@@ -1,10 +1,10 @@
-{{- if .Values.jobs.wcs-ingests.enabled }}
+{{- if .Values.jobs.wcsIngests.enabled }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: wcs-txa-ingests-job
 spec:
-  schedule: "{{ .Values.jobs.wcs-ingests.schedule }}"
+  schedule: "{{ .Values.jobs.wcsIngests.schedule }}"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
@@ -21,7 +21,7 @@ spec:
             runAsNonRoot: true
           containers:
             - name: wcs-txa-ingests-job
-              image: quay.io/ukhomeofficedigital/hocs-txa-document-extractor:{{ .Values.jobs.wcs-ingests.imageTag }}
+              image: quay.io/ukhomeofficedigital/hocs-txa-document-extractor:{{ .Values.jobs.wcsIngests.imageTag }}
               imagePullPolicy: Always
               resources:
                 limits:

--- a/charts/hocs-txa-document-extractor/values.yaml
+++ b/charts/hocs-txa-document-extractor/values.yaml
@@ -1,18 +1,18 @@
 ---
 jobs:
-  cs-ingests:
+  csIngests:
     enabled: true
     schedule: '5 8 * * *'
     imageTag: 2.0.0
-  cs-deletes:
+  csDeletes:
     enabled: true
     schedule: '5 8 * * *'
     imageTag: 2.0.0
-  wcs-ingests:
+  wcsIngests:
     enabled: true
     schedule: '5 8 * * *'
     imageTag: 2.0.0
-  wcs-deletes:
+  wcsDeletes:
     enabled: true
     schedule: '5 8 * * *'
     imageTag: 2.0.0

--- a/charts/hocs-txa-document-extractor/values.yaml
+++ b/charts/hocs-txa-document-extractor/values.yaml
@@ -3,16 +3,16 @@ jobs:
   csIngests:
     enabled: true
     schedule: '5 8 * * *'
-    imageTag: 2.0.0
+    imageTag: 2.0.1
   csDeletes:
     enabled: true
     schedule: '5 8 * * *'
-    imageTag: 2.0.0
+    imageTag: 2.0.1
   wcsIngests:
     enabled: true
     schedule: '5 8 * * *'
-    imageTag: 2.0.0
+    imageTag: 2.0.1
   wcsDeletes:
     enabled: true
     schedule: '5 8 * * *'
-    imageTag: 2.0.0
+    imageTag: 2.0.1


### PR DESCRIPTION
Fix the chart for hocs-txa-document-extractor by renaming Chart template values to remove the invalid character (Helm does not like hyphens in the names).
