### PR TITLE
Update hocs-txa-document-extractor chart to v1.0.3

### DIFF
--- a/charts/hocs-txa-document-extractor/Chart.yaml
+++ b/charts/hocs-txa-document-extractor/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: hocs-txa-document-extractor
-version: 1.0.2
+version: 1.0.3
 description: Exports a batch of documents to DSA Analytics pipeline.

--- a/charts/hocs-txa-document-extractor/templates/cs-txa-deletes-job.yml
+++ b/charts/hocs-txa-document-extractor/templates/cs-txa-deletes-job.yml
@@ -34,7 +34,7 @@ spec:
                 - configMapRef:
                     name: cs-txa-config
                 - secretRef:
-                    name: txa-secrets
+                    name: cs-txa-secrets
                 - secretRef:
                     name: aws-s3-secrets
               env:

--- a/charts/hocs-txa-document-extractor/templates/cs-txa-ingests-job.yml
+++ b/charts/hocs-txa-document-extractor/templates/cs-txa-ingests-job.yml
@@ -34,7 +34,7 @@ spec:
                 - configMapRef:
                     name: cs-txa-config
                 - secretRef:
-                    name: txa-secrets
+                    name: cs-txa-secrets
                 - secretRef:
                     name: aws-s3-secrets
               env:

--- a/charts/hocs-txa-document-extractor/templates/wcs-txa-deletes-job.yml
+++ b/charts/hocs-txa-document-extractor/templates/wcs-txa-deletes-job.yml
@@ -34,7 +34,7 @@ spec:
                 - configMapRef:
                     name: wcs-txa-config
                 - secretRef:
-                    name: txa-secrets
+                    name: wcs-txa-secrets
                 - secretRef:
                     name: aws-s3-secrets
               env:

--- a/charts/hocs-txa-document-extractor/templates/wcs-txa-ingests-job.yml
+++ b/charts/hocs-txa-document-extractor/templates/wcs-txa-ingests-job.yml
@@ -34,7 +34,7 @@ spec:
                 - configMapRef:
                     name: wcs-txa-config
                 - secretRef:
-                    name: txa-secrets
+                    name: wcs-txa-secrets
                 - secretRef:
                     name: aws-s3-secrets
               env:


### PR DESCRIPTION
Use distinct secrets for cs & wcs jobs.

In dev, all jobs used the same secret object 'txa-secrets' because the database user had the same credentials in the CS RDS as it did in the WCS RDS. This is not the case in preprod or prod - the credentials are different.

I have updated the secrets in the cs-txa-notprod namespace to convert the 1 txa-secrets secret to 2 distinct secrets (cs-txa-secrets and wcs-txa-secrets). The secrets are the cs-txa-preprod and cs-txa-prod namespaces are already split into cs-txa-secrets and wcs-txa-secrets.

This pull request is to update the helm Chart for hocs-txa-document-extractor so that the cs/wcs jobs target the correct secret in preprod & prod.