### PR TITLE
HOCS-6959 Read only access keys not available in all namespaces - use standard secrets

### DIFF
--- a/charts/hocs-toolbox/Chart.yaml
+++ b/charts/hocs-toolbox/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: hocs-toolbox
-version: 2.2.0
+version: 2.3.0

--- a/charts/hocs-toolbox/Chart.yaml
+++ b/charts/hocs-toolbox/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: hocs-toolbox
-version: 2.3.0
+version: 2.3.1

--- a/charts/hocs-toolbox/templates/_envs.tpl
+++ b/charts/hocs-toolbox/templates/_envs.tpl
@@ -16,11 +16,6 @@
     secretKeyRef:
       name: {{ $.Release.Namespace }}-trusted-s3
       key: secret_access_key
-- name: S3_BUCKET_NAME
-  valueFrom:
-    secretKeyRef:
-      name: {{ $.Release.Namespace }}-trusted-s3
-      key: bucket_name
 - name: S3_HTTPS_PROXY
   value: hocs-outbound-proxy.{{ $.Release.Namespace }}.svc.cluster.local:31290
 {{- range .Values.app.env.databases }}

--- a/charts/hocs-toolbox/templates/_envs.tpl
+++ b/charts/hocs-toolbox/templates/_envs.tpl
@@ -16,6 +16,11 @@
     secretKeyRef:
       name: {{ $.Release.Namespace }}-trusted-s3
       key: secret_access_key
+- name: S3_BUCKET_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ $.Release.Namespace }}-trusted-s3
+      key: bucket_name
 - name: S3_HTTPS_PROXY
   value: hocs-outbound-proxy.{{ $.Release.Namespace }}.svc.cluster.local:31290
 {{- range .Values.app.env.databases }}

--- a/charts/hocs-toolbox/templates/_envs.tpl
+++ b/charts/hocs-toolbox/templates/_envs.tpl
@@ -1,6 +1,23 @@
 {{- define "hocs-toolbox.envs" }}
 - name: KUBE_NAMESPACE
   value: {{ $.Release.Namespace }}
+- name: S3_BUCKET_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ $.Release.Namespace }}-trusted-s3
+      key: bucket_name
+- name: S3_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ $.Release.Namespace }}-trusted-s3
+      key: access_keys_ro_user
+- name: S3_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ $.Release.Namespace }}-trusted-s3
+      key: secret_access_keys_ro_user
+- name: S3_HTTPS_PROXY
+  value: hocs-outbound-proxy.{{ $.Release.Namespace }}.svc.cluster.local:31290
 {{- range .Values.app.env.databases }}
 - name: {{. | title | replace "-" "_" | upper }}_DB_HOST
   valueFrom:

--- a/charts/hocs-toolbox/templates/_envs.tpl
+++ b/charts/hocs-toolbox/templates/_envs.tpl
@@ -10,12 +10,12 @@
   valueFrom:
     secretKeyRef:
       name: {{ $.Release.Namespace }}-trusted-s3
-      key: access_keys_ro_user
+      key: access_key_id
 - name: S3_SECRET_ACCESS_KEY
   valueFrom:
     secretKeyRef:
       name: {{ $.Release.Namespace }}-trusted-s3
-      key: secret_access_keys_ro_user
+      key: secret_access_key
 - name: S3_HTTPS_PROXY
   value: hocs-outbound-proxy.{{ $.Release.Namespace }}.svc.cluster.local:31290
 {{- range .Values.app.env.databases }}


### PR DESCRIPTION
read only access keys are only configured for cs-prod, and aren't set for wcs-prod or the preprod environments so I've switched over to use the access keys available everywhere.