### PR TITLE
Add networkpolicy.yaml to hocs-toolbox

### DIFF
--- a/charts/hocs-toolbox/Chart.yaml
+++ b/charts/hocs-toolbox/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: hocs-toolbox
-version: 2.3.1
+version: 2.4.0

--- a/charts/hocs-toolbox/templates/networkpolicy.yaml
+++ b/charts/hocs-toolbox/templates/networkpolicy.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.networkpolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "hocs-app.name" . }}-service-policy
+spec:
+  podSelector:
+    matchLabels:
+      role: {{ include "hocs-app.name" . }}
+  policyTypes:
+    {{- if .Values.networkpolicy.ingress.enabled }}
+    - Ingress
+    {{- end }}
+    {{- if .Values.networkpolicy.egress.enabled }}
+    - Egress
+    {{- end }}
+  {{- if .Values.networkpolicy.ingress.enabled }}
+  ingress:
+    - ports:
+        {{- toYaml .Values.networkpolicy.ingress.ports | nindent 8 }}
+      from:
+        {{- toYaml .Values.networkpolicy.ingress.from | nindent 8 }}
+  {{- end }}
+  {{- if .Values.networkpolicy.egress.enabled }}
+  egress:
+    - ports:
+        {{- toYaml .Values.networkpolicy.egress.ports | nindent 8 }}
+      to:
+        {{- toYaml .Values.networkpolicy.egress.to | nindent 8 -}}
+        {{- if .Values.networkpolicy.egress.aws }}
+           {{- include "hocs-app.networkpolicy.egress.aws-cidr-blocks" . | nindent 8 }}
+        {{- end }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
As `hocs-toolbox` doesn't extend the generic service, a network policy template is not incluyded by default. This adds the policy from the generic service to the toolbox so that the added configuration in [`hocs-deployments-notprod` #227](https://github.com/UKHomeOffice/hocs-deployments-notprod/pull/227) is respected.