### PR TITLE
Add network policy to hocs toolbox

### DIFF
--- a/charts/hocs-toolbox/Chart.yaml
+++ b/charts/hocs-toolbox/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: hocs-toolbox
-version: 2.3.1
+version: 2.4.0

--- a/charts/hocs-toolbox/Chart.yaml
+++ b/charts/hocs-toolbox/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: hocs-toolbox
-version: 2.4.0
+version: 2.4.1

--- a/charts/hocs-toolbox/templates/_helpers.tpl
+++ b/charts/hocs-toolbox/templates/_helpers.tpl
@@ -29,3 +29,337 @@ database: required
 {{- end }}
 version: {{ .Values.version }}
 {{- end }}
+
+{{/*
+AWS CIDR ranges - copied from hocs-generic-service TODO move to shared chart
+*/}}
+{{- define "hocs-app.networkpolicy.egress.aws-cidr-blocks" -}}
+- ipBlock:
+    cidr: 52.93.153.170/32
+- ipBlock:
+    cidr: 13.34.52.96/27
+- ipBlock:
+    cidr: 13.34.110.128/27
+- ipBlock:
+    cidr: 52.95.150.0/24
+- ipBlock:
+    cidr: 52.93.153.148/32
+- ipBlock:
+    cidr: 150.222.238.0/24
+- ipBlock:
+    cidr: 15.230.158.0/23
+- ipBlock:
+    cidr: 52.93.56.0/24
+- ipBlock:
+    cidr: 15.248.28.0/22
+- ipBlock:
+    cidr: 51.24.0.0/13
+- ipBlock:
+    cidr: 13.34.27.32/27
+- ipBlock:
+    cidr: 13.34.96.32/27
+- ipBlock:
+    cidr: 52.144.211.196/31
+- ipBlock:
+    cidr: 15.230.9.12/31
+- ipBlock:
+    cidr: 208.78.132.0/23
+- ipBlock:
+    cidr: 15.230.9.47/32
+- ipBlock:
+    cidr: 64.252.85.0/24
+- ipBlock:
+    cidr: 216.39.136.0/21
+- ipBlock:
+    cidr: 13.34.52.64/27
+- ipBlock:
+    cidr: 15.230.106.0/24
+- ipBlock:
+    cidr: 150.222.37.192/26
+- ipBlock:
+    cidr: 13.34.79.128/27
+- ipBlock:
+    cidr: 52.93.229.149/32
+- ipBlock:
+    cidr: 15.230.189.128/25
+- ipBlock:
+    cidr: 16.12.15.0/24
+- ipBlock:
+    cidr: 35.176.0.0/15
+- ipBlock:
+    cidr: 15.193.5.0/24
+- ipBlock:
+    cidr: 13.34.85.224/27
+- ipBlock:
+    cidr: 13.34.81.224/27
+- ipBlock:
+    cidr: 99.77.156.0/24
+- ipBlock:
+    cidr: 52.56.0.0/16
+- ipBlock:
+    cidr: 52.93.153.149/32
+- ipBlock:
+    cidr: 13.34.27.0/27
+- ipBlock:
+    cidr: 16.12.16.0/23
+- ipBlock:
+    cidr: 52.93.153.177/32
+- ipBlock:
+    cidr: 15.230.9.10/31
+- ipBlock:
+    cidr: 150.222.46.0/25
+- ipBlock:
+    cidr: 52.94.32.0/20
+- ipBlock:
+    cidr: 208.78.135.0/24
+- ipBlock:
+    cidr: 52.144.211.192/31
+- ipBlock:
+    cidr: 52.94.198.144/28
+- ipBlock:
+    cidr: 13.34.66.128/27
+- ipBlock:
+    cidr: 151.148.41.0/24
+- ipBlock:
+    cidr: 15.230.173.0/24
+- ipBlock:
+    cidr: 15.230.190.128/25
+- ipBlock:
+    cidr: 52.95.253.0/24
+- ipBlock:
+    cidr: 52.93.255.0/24
+- ipBlock:
+    cidr: 13.248.120.0/24
+- ipBlock:
+    cidr: 15.230.9.45/32
+- ipBlock:
+    cidr: 52.93.153.179/32
+- ipBlock:
+    cidr: 15.230.165.0/24
+- ipBlock:
+    cidr: 99.77.134.0/24
+- ipBlock:
+    cidr: 13.34.66.160/27
+- ipBlock:
+    cidr: 13.34.79.160/27
+- ipBlock:
+    cidr: 52.93.138.0/24
+- ipBlock:
+    cidr: 150.222.134.0/24
+- ipBlock:
+    cidr: 13.34.110.160/27
+- ipBlock:
+    cidr: 52.144.211.128/26
+- ipBlock:
+    cidr: 99.82.169.0/24
+- ipBlock:
+    cidr: 13.34.96.0/27
+- ipBlock:
+    cidr: 13.34.77.32/27
+- ipBlock:
+    cidr: 13.34.91.224/27
+- ipBlock:
+    cidr: 52.93.153.80/32
+- ipBlock:
+    cidr: 52.95.148.0/23
+- ipBlock:
+    cidr: 150.222.215.0/24
+- ipBlock:
+    cidr: 15.230.153.0/24
+- ipBlock:
+    cidr: 52.144.209.192/26
+- ipBlock:
+    cidr: 52.93.80.0/24
+- ipBlock:
+    cidr: 52.144.133.32/27
+- ipBlock:
+    cidr: 52.219.219.0/24
+- ipBlock:
+    cidr: 13.34.77.160/27
+- ipBlock:
+    cidr: 52.144.211.64/26
+- ipBlock:
+    cidr: 52.93.153.176/32
+- ipBlock:
+    cidr: 52.93.153.169/32
+- ipBlock:
+    cidr: 150.222.65.0/24
+- ipBlock:
+    cidr: 150.222.37.128/26
+- ipBlock:
+    cidr: 52.93.229.148/32
+- ipBlock:
+    cidr: 52.94.48.0/20
+- ipBlock:
+    cidr: 52.93.153.171/32
+- ipBlock:
+    cidr: 18.168.0.0/14
+- ipBlock:
+    cidr: 150.222.37.64/26
+- ipBlock:
+    cidr: 52.93.153.168/32
+- ipBlock:
+    cidr: 18.175.0.0/16
+- ipBlock:
+    cidr: 52.95.239.0/24
+- ipBlock:
+    cidr: 13.34.91.192/27
+- ipBlock:
+    cidr: 52.94.112.0/22
+- ipBlock:
+    cidr: 150.222.207.0/24
+- ipBlock:
+    cidr: 13.34.26.192/27
+- ipBlock:
+    cidr: 52.144.213.64/26
+- ipBlock:
+    cidr: 13.34.18.128/27
+- ipBlock:
+    cidr: 18.132.0.0/14
+- ipBlock:
+    cidr: 15.230.9.248/32
+- ipBlock:
+    cidr: 15.230.255.0/24
+- ipBlock:
+    cidr: 52.93.139.0/24
+- ipBlock:
+    cidr: 52.144.211.198/31
+- ipBlock:
+    cidr: 64.252.84.0/24
+- ipBlock:
+    cidr: 150.222.46.128/25
+- ipBlock:
+    cidr: 52.93.153.174/32
+- ipBlock:
+    cidr: 64.252.83.0/24
+- ipBlock:
+    cidr: 13.34.85.192/27
+- ipBlock:
+    cidr: 52.93.153.175/32
+- ipBlock:
+    cidr: 99.77.249.0/24
+- ipBlock:
+    cidr: 35.178.0.0/15
+- ipBlock:
+    cidr: 52.94.15.0/24
+- ipBlock:
+    cidr: 52.95.144.0/24
+- ipBlock:
+    cidr: 52.95.142.0/23
+- ipBlock:
+    cidr: 64.252.82.0/24
+- ipBlock:
+    cidr: 15.230.9.46/32
+- ipBlock:
+    cidr: 35.71.111.0/24
+- ipBlock:
+    cidr: 99.150.40.0/21
+- ipBlock:
+    cidr: 15.230.55.0/24
+- ipBlock:
+    cidr: 15.230.9.252/31
+- ipBlock:
+    cidr: 52.95.191.0/24
+- ipBlock:
+    cidr: 13.34.81.192/27
+- ipBlock:
+    cidr: 52.94.248.192/28
+- ipBlock:
+    cidr: 15.177.78.0/24
+- ipBlock:
+    cidr: 13.34.52.192/27
+- ipBlock:
+    cidr: 173.83.206.0/23
+- ipBlock:
+    cidr: 3.2.48.0/24
+- ipBlock:
+    cidr: 54.239.0.240/28
+- ipBlock:
+    cidr: 3.8.0.0/14
+- ipBlock:
+    cidr: 150.222.67.0/24
+- ipBlock:
+    cidr: 15.221.48.0/24
+- ipBlock:
+    cidr: 52.144.209.64/26
+- ipBlock:
+    cidr: 18.130.0.0/16
+- ipBlock:
+    cidr: 52.144.211.200/31
+- ipBlock:
+    cidr: 52.93.153.172/32
+- ipBlock:
+    cidr: 15.230.86.0/24
+- ipBlock:
+    cidr: 52.94.160.0/20
+- ipBlock:
+    cidr: 13.34.52.224/27
+- ipBlock:
+    cidr: 3.5.244.0/22
+- ipBlock:
+    cidr: 13.34.77.0/27
+- ipBlock:
+    cidr: 52.93.153.173/32
+- ipBlock:
+    cidr: 52.144.211.202/31
+- ipBlock:
+    cidr: 13.34.27.64/27
+- ipBlock:
+    cidr: 15.230.9.44/32
+- ipBlock:
+    cidr: 13.34.18.160/27
+- ipBlock:
+    cidr: 13.34.52.128/27
+- ipBlock:
+    cidr: 13.40.0.0/14
+- ipBlock:
+    cidr: 13.34.48.96/27
+- ipBlock:
+    cidr: 15.230.9.14/31
+- ipBlock:
+    cidr: 150.222.29.0/24
+- ipBlock:
+    cidr: 13.248.101.0/24
+- ipBlock:
+    cidr: 52.144.211.194/31
+- ipBlock:
+    cidr: 15.230.43.0/24
+- ipBlock:
+    cidr: 13.34.48.64/27
+- ipBlock:
+    cidr: 13.34.52.160/27
+- ipBlock:
+    cidr: 52.93.153.178/32
+- ipBlock:
+    cidr: 54.239.100.0/23
+- ipBlock:
+    cidr: 13.34.77.128/27
+- ipBlock:
+    cidr: 150.222.45.128/25
+- ipBlock:
+    cidr: 216.39.152.0/21
+- ipBlock:
+    cidr: 15.230.190.0/25
+- ipBlock:
+    cidr: 13.40.1.192/26
+- ipBlock:
+    cidr: 13.41.1.160/27
+- ipBlock:
+    cidr: 13.43.44.0/22
+- ipBlock:
+    cidr: 13.43.48.0/23
+- ipBlock:
+    cidr: 18.132.146.192/26
+- ipBlock:
+    cidr: 18.133.45.0/26
+- ipBlock:
+    cidr: 18.133.45.64/26
+- ipBlock:
+    cidr: 18.171.35.128/26
+- ipBlock:
+    cidr: 3.10.201.128/27
+- ipBlock:
+    cidr: 3.10.201.192/26
+- ipBlock:
+    cidr: 3.8.168.0/23
+{{- end }}

--- a/charts/hocs-toolbox/templates/networkpolicy.yaml
+++ b/charts/hocs-toolbox/templates/networkpolicy.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.networkpolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "hocs-app.name" . }}-service-policy
+spec:
+  podSelector:
+    matchLabels:
+      role: {{ include "hocs-app.name" . }}
+  policyTypes:
+    {{- if .Values.networkpolicy.ingress.enabled }}
+    - Ingress
+    {{- end }}
+    {{- if .Values.networkpolicy.egress.enabled }}
+    - Egress
+    {{- end }}
+  {{- if .Values.networkpolicy.ingress.enabled }}
+  ingress:
+    - ports:
+        {{- toYaml .Values.networkpolicy.ingress.ports | nindent 8 }}
+      from:
+        {{- toYaml .Values.networkpolicy.ingress.from | nindent 8 }}
+  {{- end }}
+  {{- if .Values.networkpolicy.egress.enabled }}
+  egress:
+    - ports:
+        {{- toYaml .Values.networkpolicy.egress.ports | nindent 8 }}
+      to:
+        {{- toYaml .Values.networkpolicy.egress.to | nindent 8 -}}
+        {{- if .Values.networkpolicy.egress.aws }}
+           {{- include "hocs-app.networkpolicy.egress.aws-cidr-blocks" . | nindent 8 }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/hocs-toolbox/templates/networkpolicy.yaml
+++ b/charts/hocs-toolbox/templates/networkpolicy.yaml
@@ -27,9 +27,11 @@ spec:
     - ports:
         {{- toYaml .Values.networkpolicy.egress.ports | nindent 8 }}
       to:
-        {{- toYaml .Values.networkpolicy.egress.to | nindent 8 -}}
+        {{- with .Values.networkpolicy.egress.to }}
+{{ toYaml . | nindent 8 }}
+        {{- end }}
         {{- if .Values.networkpolicy.egress.aws }}
-           {{- include "hocs-app.networkpolicy.egress.aws-cidr-blocks" . | nindent 8 }}
+{{ include "hocs-app.networkpolicy.egress.aws-cidr-blocks" . | nindent 8 }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/hocs-toolbox/values.yaml
+++ b/charts/hocs-toolbox/values.yaml
@@ -19,6 +19,13 @@ deployment:
         - SETUID
         - SETGID
 
+networkpolicy:
+  enabled: false
+  egress:
+    enabled: false
+  ingress:
+    enabled: false
+
 app:
   image:
     repository: quay.io/ukhomeofficedigital/hocs-toolbox


### PR DESCRIPTION
Fixes from chart failing to deploy

- Needs default enabled: false for networkpolicy, ingress, egress
- Needs AWS cidr blocks defining